### PR TITLE
Create Blazor PWA with camera capture support

### DIFF
--- a/NCS-TEST1.sln
+++ b/NCS-TEST1.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NCS-TEST1", "NCS-TEST1\\NCS-TEST1.csproj", "{0ED406FE-1485-4993-8340-05AA88F7E6EE}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {0ED406FE-1485-4993-8340-05AA88F7E6EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {0ED406FE-1485-4993-8340-05AA88F7E6EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {0ED406FE-1485-4993-8340-05AA88F7E6EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {0ED406FE-1485-4993-8340-05AA88F7E6EE}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+    GlobalSection(ExtensibilityGlobals) = postSolution
+        SolutionGuid = {86370870-0FB2-4B75-ACCA-C3FB134D964F}
+    EndGlobalSection
+EndGlobal

--- a/NCS-TEST1/App.razor
+++ b/NCS-TEST1/App.razor
@@ -1,0 +1,16 @@
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+
+<Router AppAssembly="typeof(App).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)" />
+        <FocusOnNavigate RouteData="routeData" Selector="h1" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="typeof(MainLayout)">
+            <p role="alert">Sorry, es konnte keine Seite für diese Adresse gefunden werden.</p>
+        </LayoutView>
+    </NotFound>
+</Router>
+
+<HeadOutlet />

--- a/NCS-TEST1/NCS-TEST1.csproj
+++ b/NCS-TEST1/NCS-TEST1.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>NcsTest1</RootNamespace>
+    <AssemblyName>NcsTest1</AssemblyName>
+    <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.8" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/NCS-TEST1/Pages/Index.razor
+++ b/NCS-TEST1/Pages/Index.razor
@@ -1,0 +1,98 @@
+@page "/"
+
+<PageTitle>Coin Snapper</PageTitle>
+
+<section class="camera-intro">
+    <h1>Münzaufnahme</h1>
+    <p>
+        Verwende die Kamera deines Geräts, um schnell eine Münze aufzunehmen.
+        Die Aufnahme wird lokal im Browser gespeichert, sodass sie auch offline
+        verfügbar bleibt.
+    </p>
+</section>
+
+<div class="camera-actions">
+    <InputFile OnChange="HandleImage" accept="image/*" Capture="environment" />
+    <button class="btn-clear" @onclick="ClearPhoto" disabled="@(_photoDataUrl is null)">
+        Aufnahme zurücksetzen
+    </button>
+</div>
+
+@if (!string.IsNullOrEmpty(_statusMessage))
+{
+    <p class="status-message">@_statusMessage</p>
+}
+
+@if (_photoDataUrl is not null)
+{
+    <section class="preview">
+        <h2>Gespeicherte Münze</h2>
+        <img src="@_photoDataUrl" alt="Aufgenommene Münze" />
+        <p class="hint">Die Aufnahme wird sicher im lokalen Speicher abgelegt.</p>
+    </section>
+}
+else
+{
+    <section class="preview placeholder">
+        <h2>Noch keine Aufnahme</h2>
+        <p>Nimm eine Münze auf, um hier eine Vorschau zu sehen.</p>
+    </section>
+}
+
+<section class="usage-tips">
+    <h2>Tipps für scharfe Aufnahmen</h2>
+    <ul>
+        <li>Platziere die Münze auf einem kontrastreichen Hintergrund.</li>
+        <li>Halte das Gerät ruhig oder verwende eine Auflage.</li>
+        <li>Nutze bei Bedarf die Taschenlampe deines Geräts für gleichmäßiges Licht.</li>
+    </ul>
+</section>
+
+@code {
+    private const long MaxFileSize = 5 * 1024 * 1024; // 5 MB
+    private string? _photoDataUrl;
+    private string? _statusMessage;
+
+    [Inject]
+    private IJSRuntime JSRuntime { get; set; } = default!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _photoDataUrl = await JSRuntime.InvokeAsync<string?>("ncsCamera.loadPhoto");
+        if (_photoDataUrl is not null)
+        {
+            _statusMessage = "Eine zuvor gespeicherte Aufnahme wurde geladen.";
+        }
+    }
+
+    private async Task HandleImage(InputFileChangeEventArgs args)
+    {
+        var file = args.File;
+        if (file is null)
+        {
+            _statusMessage = "Es wurde keine Datei ausgewählt.";
+            return;
+        }
+
+        if (file.Size > MaxFileSize)
+        {
+            _statusMessage = "Die Aufnahme ist zu groß. Bitte wähle eine Datei unter 5 MB.";
+            return;
+        }
+
+        await using var stream = file.OpenReadStream(MaxFileSize);
+        using var memoryStream = new MemoryStream();
+        await stream.CopyToAsync(memoryStream);
+        var base64 = Convert.ToBase64String(memoryStream.ToArray());
+        _photoDataUrl = $"data:{file.ContentType};base64,{base64}";
+        await JSRuntime.InvokeVoidAsync("ncsCamera.savePhoto", _photoDataUrl);
+        _statusMessage = $"Aufnahme gespeichert ({file.Name}).";
+    }
+
+    private async Task ClearPhoto()
+    {
+        await JSRuntime.InvokeVoidAsync("ncsCamera.clearPhoto");
+        _photoDataUrl = null;
+        _statusMessage = "Die Aufnahme wurde entfernt.";
+    }
+}

--- a/NCS-TEST1/Pages/Index.razor.css
+++ b/NCS-TEST1/Pages/Index.razor.css
@@ -1,0 +1,104 @@
+.camera-intro {
+    max-width: 700px;
+    margin-bottom: 1.5rem;
+}
+
+.camera-intro h1 {
+    font-size: clamp(2rem, 4vw, 3rem);
+    margin-bottom: 0.5rem;
+}
+
+.camera-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.camera-actions input[type="file"] {
+    padding: 0.75rem;
+    border: 2px dashed rgba(51, 33, 18, 0.4);
+    border-radius: 0.75rem;
+    background-color: rgba(255, 255, 255, 0.7);
+    cursor: pointer;
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.camera-actions input[type="file"]:focus {
+    outline: none;
+    border-color: rgba(51, 33, 18, 0.8);
+    background-color: rgba(255, 255, 255, 0.9);
+}
+
+.btn-clear {
+    padding: 0.75rem 1.5rem;
+    border-radius: 999px;
+    border: none;
+    font-size: 1rem;
+    background-color: #c77d2a;
+    color: #fff8e1;
+    cursor: pointer;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.btn-clear:disabled {
+    background-color: rgba(199, 125, 42, 0.4);
+    cursor: not-allowed;
+}
+
+.btn-clear:not(:disabled):hover {
+    background-color: #a8641f;
+    transform: translateY(-1px);
+}
+
+.status-message {
+    margin-bottom: 1rem;
+    font-weight: 600;
+}
+
+.preview {
+    background-color: rgba(255, 255, 255, 0.8);
+    padding: 1.5rem;
+    border-radius: 1rem;
+    box-shadow: 0 10px 30px rgba(44, 24, 16, 0.2);
+    max-width: 480px;
+    text-align: center;
+}
+
+.preview img {
+    width: min(100%, 420px);
+    border-radius: 0.75rem;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+    margin-bottom: 0.75rem;
+}
+
+.preview.placeholder {
+    border: 2px dashed rgba(51, 33, 18, 0.3);
+    background-color: rgba(255, 255, 255, 0.6);
+}
+
+.preview .hint {
+    font-size: 0.95rem;
+    color: rgba(44, 24, 16, 0.75);
+}
+
+.usage-tips {
+    margin-top: 2rem;
+    max-width: 600px;
+}
+
+.usage-tips ul {
+    padding-left: 1.25rem;
+}
+
+@media (max-width: 600px) {
+    .camera-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .btn-clear {
+        width: 100%;
+    }
+}

--- a/NCS-TEST1/Program.cs
+++ b/NCS-TEST1/Program.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using NcsTest1;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>("#app");
+builder.RootComponents.Add<HeadOutlet>("head::after");
+
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+
+await builder.Build().RunAsync();

--- a/NCS-TEST1/Properties/launchSettings.json
+++ b/NCS-TEST1/Properties/launchSettings.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "NCS-TEST1": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/NCS-TEST1/Shared/MainLayout.razor
+++ b/NCS-TEST1/Shared/MainLayout.razor
@@ -1,0 +1,16 @@
+@inherits LayoutComponentBase
+
+<div class="main-layout">
+    <header class="top-bar">
+        <h1>Nasreddin's Coin Snapper</h1>
+        <p class="tagline">Progressive Web App zum Fotografieren von Münzen</p>
+    </header>
+
+    <main>
+        @Body
+    </main>
+
+    <footer>
+        <p>&copy; @DateTime.Now.Year Nasreddin's Coin Snapper</p>
+    </footer>
+</div>

--- a/NCS-TEST1/Shared/MainLayout.razor.css
+++ b/NCS-TEST1/Shared/MainLayout.razor.css
@@ -1,0 +1,47 @@
+.main-layout {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    background: radial-gradient(circle at top, #fdf6e3, #f5deb3);
+    color: #2c1810;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.top-bar {
+    background-color: rgba(51, 33, 18, 0.85);
+    color: #fff8e1;
+    padding: 1.5rem 2rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.top-bar h1 {
+    margin: 0;
+    font-size: 2rem;
+}
+
+.top-bar .tagline {
+    margin: 0.25rem 0 0;
+    opacity: 0.85;
+}
+
+main {
+    flex: 1;
+    padding: 2rem clamp(1rem, 3vw, 4rem);
+}
+
+footer {
+    padding: 1rem 2rem;
+    background-color: rgba(51, 33, 18, 0.7);
+    color: #f0e6d2;
+    text-align: center;
+}
+
+@media (max-width: 600px) {
+    .top-bar h1 {
+        font-size: 1.6rem;
+    }
+
+    main {
+        padding: 1.5rem;
+    }
+}

--- a/NCS-TEST1/_Imports.razor
+++ b/NCS-TEST1/_Imports.razor
@@ -1,0 +1,7 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.WebAssembly.Http
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.JSInterop
+@using NcsTest1

--- a/NCS-TEST1/wwwroot/css/app.css
+++ b/NCS-TEST1/wwwroot/css/app.css
@@ -1,0 +1,29 @@
+:root {
+    color-scheme: light dark;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    background: #f1e1c1;
+}
+
+body, button {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+a {
+    color: #c77d2a;
+}
+
+a:hover {
+    text-decoration: none;
+}
+
+button {
+    font-family: inherit;
+}
+
+#app {
+    min-height: 100vh;
+}

--- a/NCS-TEST1/wwwroot/icons/icon-192.svg
+++ b/NCS-TEST1/wwwroot/icons/icon-192.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <defs>
+    <radialGradient id="grad" cx="50%" cy="50%" r="70%">
+      <stop offset="0%" stop-color="#ffe8a3" />
+      <stop offset="100%" stop-color="#c77d2a" />
+    </radialGradient>
+  </defs>
+  <rect width="192" height="192" rx="32" fill="url(#grad)" />
+  <circle cx="96" cy="96" r="58" fill="rgba(255,255,255,0.6)" />
+  <text x="96" y="108" font-size="64" font-family="'Segoe UI', sans-serif" text-anchor="middle" fill="#3a1f0c">₿</text>
+</svg>

--- a/NCS-TEST1/wwwroot/icons/icon-512.svg
+++ b/NCS-TEST1/wwwroot/icons/icon-512.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <radialGradient id="grad512" cx="50%" cy="50%" r="70%">
+      <stop offset="0%" stop-color="#ffe8a3" />
+      <stop offset="100%" stop-color="#c77d2a" />
+    </radialGradient>
+    <radialGradient id="shine" cx="30%" cy="30%" r="50%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.85)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </radialGradient>
+  </defs>
+  <rect width="512" height="512" rx="80" fill="url(#grad512)" />
+  <circle cx="256" cy="256" r="170" fill="rgba(255,255,255,0.6)" />
+  <circle cx="200" cy="180" r="130" fill="url(#shine)" />
+  <text x="256" y="298" font-size="180" font-family="'Segoe UI', sans-serif" text-anchor="middle" fill="#3a1f0c">₿</text>
+</svg>

--- a/NCS-TEST1/wwwroot/index.html
+++ b/NCS-TEST1/wwwroot/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nasreddin's Coin Snapper</title>
+    <link rel="manifest" href="manifest.json" />
+    <meta name="theme-color" content="#c77d2a" />
+    <link rel="icon" type="image/svg+xml" href="icons/icon-192.svg" />
+    <link rel="stylesheet" href="css/app.css" />
+</head>
+<body>
+    <div id="app">Wird geladen...</div>
+
+    <script src="_framework/blazor.webassembly.js"></script>
+    <script src="js/cameraStorage.js"></script>
+    <script>
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('service-worker.js');
+        }
+    </script>
+</body>
+</html>

--- a/NCS-TEST1/wwwroot/js/cameraStorage.js
+++ b/NCS-TEST1/wwwroot/js/cameraStorage.js
@@ -1,0 +1,20 @@
+window.ncsCamera = {
+    savePhoto: function (dataUrl) {
+        if (!dataUrl) {
+            window.localStorage.removeItem('ncs-camera-photo');
+            return;
+        }
+
+        try {
+            window.localStorage.setItem('ncs-camera-photo', dataUrl);
+        } catch (error) {
+            console.error('Konnte Foto nicht speichern', error);
+        }
+    },
+    loadPhoto: function () {
+        return window.localStorage.getItem('ncs-camera-photo');
+    },
+    clearPhoto: function () {
+        window.localStorage.removeItem('ncs-camera-photo');
+    }
+};

--- a/NCS-TEST1/wwwroot/manifest.json
+++ b/NCS-TEST1/wwwroot/manifest.json
@@ -1,0 +1,24 @@
+{
+  "name": "Nasreddin's Coin Snapper",
+  "short_name": "CoinSnapper",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#f1e1c1",
+  "theme_color": "#c77d2a",
+  "description": "PWA zum Aufnehmen und Speichern von Münzaufnahmen mit der Gerätekamera.",
+  "lang": "de-DE",
+  "icons": [
+    {
+      "src": "icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "icons/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/NCS-TEST1/wwwroot/service-worker.js
+++ b/NCS-TEST1/wwwroot/service-worker.js
@@ -1,0 +1,44 @@
+const CACHE_NAME = 'ncs-coinsnapper-cache-v1';
+const OFFLINE_URLS = [
+    './',
+    './index.html',
+    './css/app.css',
+    './manifest.json',
+    './js/cameraStorage.js',
+    './icons/icon-192.svg',
+    './icons/icon-512.svg'
+];
+
+self.addEventListener('install', event => {
+    event.waitUntil(
+        caches.open(CACHE_NAME).then(cache => cache.addAll(OFFLINE_URLS))
+    );
+});
+
+self.addEventListener('activate', event => {
+    event.waitUntil(
+        caches.keys().then(keys =>
+            Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+        )
+    );
+});
+
+self.addEventListener('fetch', event => {
+    if (event.request.method !== 'GET') {
+        return;
+    }
+
+    event.respondWith(
+        caches.match(event.request).then(cachedResponse => {
+            if (cachedResponse) {
+                return cachedResponse;
+            }
+
+            return fetch(event.request).then(response => {
+                const copy = response.clone();
+                caches.open(CACHE_NAME).then(cache => cache.put(event.request, copy));
+                return response;
+            }).catch(() => caches.match('./index.html'));
+        })
+    );
+});

--- a/NCS-TEST1/wwwroot/service-worker.published.js
+++ b/NCS-TEST1/wwwroot/service-worker.published.js
@@ -1,0 +1,1 @@
+importScripts('./service-worker.js');

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
-# Nasreddins-Coin-Snapper
-Project in planning - nothing interessting here, yet
+# Nasreddin's Coin Snapper
+
+Eine progressive Web-App auf Basis von Blazor WebAssembly zum Aufnehmen und Speichern von Münzaufnahmen.
+
+## Projektaufbau
+
+- `NCS-TEST1.sln` – Visual-Studio-Lösung mit dem Blazor-Projekt.
+- `NCS-TEST1/` – Quellcode der Anwendung inklusive PWA-Assets, Service-Worker und lokaler Speicherlogik.
+
+## Funktionen
+
+- Kameraaufnahme über `<InputFile>` mit `capture="environment"` für Mobilgeräte.
+- Vorschau der aufgenommenen Münze direkt in der App.
+- Persistente Speicherung des Fotos im `localStorage`, damit die Aufnahme offline verfügbar bleibt.
+- Service Worker und Manifest für die Nutzung als Progressive Web App.
+
+## Entwicklung starten
+
+1. .NET 8 SDK installieren.
+2. Abhängigkeiten wiederherstellen und Entwicklungsserver starten:
+
+   ```bash
+   dotnet restore NCS-TEST1/NCS-TEST1.csproj
+   dotnet run --project NCS-TEST1/NCS-TEST1.csproj
+   ```
+
+3. Die Anwendung ist anschließend unter `https://localhost:5001` bzw. `http://localhost:5000` erreichbar.
+
+Für die PWA-Funktionen (Installierbarkeit, Offline-Nutzung) sollte die App über HTTPS ausgeliefert werden.


### PR DESCRIPTION
## Summary
- add the new `NCS-TEST1` Blazor WebAssembly solution that serves as a PWA
- implement a camera capture page that stores the taken photo in localStorage and shows a preview
- include PWA assets (service worker, manifest, icons) and update the README with usage instructions

## Testing
- not run (dotnet SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68de792b16cc8323ba24d65f01483684