### PR TITLE
Allow intranet clients to reach development server

### DIFF
--- a/NCS-TEST1/Properties/launchSettings.json
+++ b/NCS-TEST1/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "applicationUrl": "https://0.0.0.0:5001;http://0.0.0.0:5000",
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ Eine progressive Web-App auf Basis von Blazor WebAssembly zum Aufnehmen und Spei
    dotnet run --project NCS-TEST1/NCS-TEST1.csproj
    ```
 
-3. Die Anwendung ist anschließend unter `https://localhost:5001` bzw. `http://localhost:5000` erreichbar.
+3. Die Anwendung ist anschließend unter `https://localhost:5001` bzw. `http://localhost:5000` erreichbar. Für den Zugriff anderer Geräte im selben Intranet stellt der Entwicklungsserver die Anwendung zusätzlich unter `https://<HOST-IP>:5001` bzw. `http://<HOST-IP>:5000` bereit.
 
 Für die PWA-Funktionen (Installierbarkeit, Offline-Nutzung) sollte die App über HTTPS ausgeliefert werden.


### PR DESCRIPTION
## Summary
- expose the development server on all interfaces so intranet devices can connect
- document that the app is reachable via the host IP for phones on the same network

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0ddf2e204832387c0f550ddb5d278